### PR TITLE
Update Location type

### DIFF
--- a/types/Location.js
+++ b/types/Location.js
@@ -2,8 +2,10 @@
 
 var GraphQL = require('graphql');
 
-var KeystoneLocationType = new GraphQL.GraphQObjectType({
-	name: 'Keystone Location',
+var GeoPoint = require('./GeoPoint');
+
+var KeystoneLocationType = new GraphQL.GraphQLObjectType({
+	name: 'KeystoneLocation',
 	fields: {
 		name: {
 			type: GraphQL.GraphQLString,
@@ -37,10 +39,7 @@ var KeystoneLocationType = new GraphQL.GraphQObjectType({
 			type: GraphQL.GraphQLString,
 			description: 'Location country',
 		},
-		geo: {
-			type: GraphQL.GraphQLList(GraphQL.GraphQLString),
-			description: 'An array [longitude, latitude]',
-		},
+		geo: GeoPoint,
 	},
 });
 


### PR DESCRIPTION
Fix typo, add GeoPoint from file for avoid graphql mistakes such as:

- Names must match  /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' Keystone Location ' does not - as GraphQL assertValidName error shows.

- Fixes GraphQL error "throw new TypeError("Cannot call a class as a function");",

- Avoiding code repeating